### PR TITLE
Set new graphcool endpoint url

### DIFF
--- a/lib/initApollo.js
+++ b/lib/initApollo.js
@@ -12,7 +12,7 @@ if (!process.browser) {
 
 function create (initialState, { getToken }) {
   const httpLink = createHttpLink({
-    uri: 'https://api.graph.cool/simple/v1/frontity-ads-form',
+    uri: 'https://api.graph.cool/simple/v1/frontity-v1',
     credentials: 'same-origin'
   })
 


### PR DESCRIPTION
We are moving from `frontity-ads-form` to `frontity-v1`. This will allow us to have different versions of the database in the future.